### PR TITLE
Get duration of a known github workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ HOST_ARCH := ${OS}_${ARCH}
 .ONESHELL: all requirements tests install
 .EXPORT_ALL_VARIABLES:
 
-all: requirements
+all: requirements install
 
 requirements:
 ifeq (, $(shell which python))
@@ -17,12 +17,12 @@ endif
 
 # install pip lib
 install:
-	pip install -r ./requirements.txt > /dev/null
+	pip install -r ./requirements.txt
 
 # Run all tests
-tests: install
+tests:
 	pytest --log-cli-level=INFO --disable-warnings -s tests/
 
 # Run all tests
-test: install
-	pytest --log-cli-level=INFO --disable-warnings tests/ -s -k $(tests)
+test:
+	pytest --log-cli-level=DEBUG --disable-warnings tests/ -s -k $(tests)

--- a/gh/auth.py
+++ b/gh/auth.py
@@ -1,0 +1,11 @@
+from github import Github
+from github.Organization import Organization
+from github.Team import Team
+from github import Auth
+
+def init(token:str, organisation_slug:str=None, team_slug:str=None ) -> tuple:
+    """Generate github, org and team instances"""
+    g:Github = Github(auth=Auth.Token(token))
+    org:Organization = g.get_organization(organisation_slug) if organisation_slug is not None else None
+    team:Team = org.get_team_by_slug(team_slug) if team_slug is not None else None
+    return g, org, team

--- a/gh/workflows.py
+++ b/gh/workflows.py
@@ -1,0 +1,45 @@
+import logging
+from github.WorkflowRun import WorkflowRun
+from github.WorkflowJob import WorkflowJob
+from github.PaginatedList import PaginatedList
+from github.Repository import Repository
+from timer.stopwatch import durations
+
+
+def workflow_total_durations(r:Repository, workflow_id:int) -> dict:
+    """Returns total duration of this workflow by adding the duration of each job within this workflow.
+
+    Parameters:
+    r (Repository): Repository object to fetch workflow from
+    workflow_id (int): The id of the workflow to use
+
+    Returns:
+    dict (str: float): total durations in various units of time
+    """
+    workflow:WorkflowRun = r.get_workflow_run(workflow_id)
+    jobs:PaginatedList[WorkflowJob] = workflow.jobs()
+    total_durations:dict = {}
+
+    for job in jobs:
+        job_durations = durations(job.started_at.isoformat(), job.completed_at.isoformat())
+        # sum together values
+        for k,v in job_durations.items():
+            total_durations[k] = total_durations.get(k, 0.0) + v
+
+        logging.debug(f"[workflow:{workflow.name}][job:{job.name}] duration: [{job_durations.get('seconds')}]")
+
+    logging.info(f"[workflow:{workflow.name}] >> total duration: [{total_durations.get('seconds')}]")
+    return total_durations
+
+def workflow_total_duration(r:Repository, workflow_id:int) -> int:
+    """Retuns how long workflow took to complete (via sum of job execution time) in rounded seconds.
+
+    Parameters:
+    r (Repository): Repository object to fetch workflow from
+    workflow_id (int): The id of the workflow to use
+
+    Returns:
+    int: total durations in seconds
+    """
+    total_durations:dict = workflow_total_durations(r, workflow_id)
+    return round(total_durations.get('seconds', 0))

--- a/github_workflow_duration.py
+++ b/github_workflow_duration.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+from gh.auth import init
+from gh.workflows import workflow_total_durations
+from github import Github
+from github.Repository import Repository
+
+
+
+def main() :
+    # handle args
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", help="Full name of the repository, including owner", required=True, type=str)
+    parser.add_argument("--workflow", help="Workflow id to calculate the duration of", required=True, type=int)
+    args = parser.parse_args()
+    # setup auth
+    token = str( os.environ.get("GH_TOKEN", "" ))
+    g:Github
+    g, _, _ = init(token)
+    # find the repo
+    r:Repository = g.get_repo(str(args.repository))
+
+    durations:dict = workflow_total_durations(r, int(args.workflow))
+    # output all values
+
+    for key, value in durations.items():
+        print(f'{key}={value}')
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -1,0 +1,21 @@
+import pytest
+from github import Github
+from github.Repository import Repository
+
+from pprint import pp
+from gh.workflows import workflow_total_duration
+
+
+# creates real api calls, to is rate limited
+@pytest.mark.parametrize("test_repo, test_workflow, expected_duration",
+[
+    # use a known workflow to find its duration
+    ("ministryofjustice/opg-github-actions", 8434061820, 112),
+    ("ministryofjustice/opg-dora-metrics", 8440646171, 133)
+])
+def test_workflow_total_duration(test_repo:str, test_workflow:int, expected_duration:int) :
+    """Test that workflow total duration in seconds matches"""
+    g:Github = Github()
+    r:Repository = g.get_repo(test_repo)
+
+    assert workflow_total_duration(r, test_workflow) == expected_duration

--- a/timer.py
+++ b/timer.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 from timer.stopwatch import start, stop, durations
 

--- a/timer/stopwatch.py
+++ b/timer/stopwatch.py
@@ -30,10 +30,8 @@ def duration(start: str, stop: str) -> int:
     Returns:
     int: Rounded number of seconds between the timestamps
     """
-    start_ts = datetime.fromisoformat(start)
-    stop_ts = datetime.fromisoformat(stop)
-    diff = stop_ts - start_ts
-    seconds = diff / timedelta(seconds=1)
+    data:dict = durations(start, stop)
+    seconds = data.get('seconds', 0.0)
     return round(seconds)
 
 def durations(start: str, stop: str) -> dict:


### PR DESCRIPTION
- The github api doesnt provide a total time at workflow level, so fetch job data and total those 
- This is a rate limited api call - need to check what that limit is and handle it 
- Add happy path tests to check the totals work
- makefile tweak